### PR TITLE
Allow Flask app to be accessible on local network (bind to 0.0.0.0)

### DIFF
--- a/main.py
+++ b/main.py
@@ -421,4 +421,4 @@ if __name__ == "__main__":
     local_url = f"http://127.0.0.1:{port}"
     print(f"Starting Pyla web UI at {local_url}")
     open_browser_later(local_url)
-    app.run(host="127.0.0.1", port=port, debug=False, use_reloader=False)
+    app.run(host="0.0.0.0", port=port, debug=False, use_reloader=False)


### PR DESCRIPTION
Updated Flask app host from 127.0.0.1 to 0.0.0.0 so the server can be accessed from other devices on the same local network.